### PR TITLE
Ensure nil values are also skipped

### DIFF
--- a/templates/sshd_config-match.erb
+++ b/templates/sshd_config-match.erb
@@ -2,9 +2,9 @@ Match <%= @name %>
 <%-
   @valid_keywords.map do |kw|
     next if scope[kw.downcase] == :undef
+    next if scope[kw.downcase] == nil
 -%>
   <%= [kw,scope[kw.downcase]].join(' ') %>
 <%-
   end
 -%>
-


### PR DESCRIPTION
Due to the ebb and flow of undef in Puppet, we need to also account for
nil values in template resulting from undef values in Puppet.

This work will skip nil values, as well as undef values in the match
template.