### PR TITLE
Fix key hostnames

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,5 +50,5 @@ task :test => [
   :syntax,
   :lint,
   :spec,
-  :metadata,
+  :metadata_lint,
 ]

--- a/manifests/hosts.pp
+++ b/manifests/hosts.pp
@@ -2,26 +2,33 @@
 #
 # Distribute ssh-dss host keys from all hosts to all hosts.
 #
-class ssh::hosts {
+class ssh::hosts (
+  $host_aliases = [$trusted['certname'], $trusted['hostname']],
+){
+
+  validate_array($host_aliases)
 
   if $::sshdsakey {
     @@sshkey { "sshdsakey-${::hostname}":
-      type => 'ssh-dss',
-      key  => $::sshdsakey,
+      host_aliases => $host_aliases,
+      type         => 'ssh-dss',
+      key          => $::sshdsakey,
     }
   }
 
   if $::sshecdsakey {
     @@sshkey { "sshecdsakey-${::hostname}":
-      type => 'ecdsa-sha2-nistp256',
-      key  => $::sshecdsakey,
+      host_aliases => $host_aliases,
+      type         => 'ecdsa-sha2-nistp256',
+      key          => $::sshecdsakey,
     }
   }
 
   if $::sshed25519key {
     @@sshkey { "sshed25519key-${::hostname}":
-      type => 'ssh-ed25519',
-      key  => $::sshed25519key,
+      host_aliases => $host_aliases,
+      type         => 'ssh-ed25519',
+      key          => $::sshed25519key,
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,6 +8,9 @@ class ssh::install (
   $ssh_packages  = $ssh::params::ssh_packages,
 ) inherits ssh::params {
 
+  validate_re($ensure, ['present', 'absent', 'latest'])
+  validate_bool($needs_install)
+
   if $needs_install == true {
     package { $ssh_packages:
       ensure => $ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,10 +8,10 @@ class ssh::params {
   $known_hosts = "${ssh_dir}/ssh_known_hosts"
 
   case $::kernel {
-    'openbsd': {
+    'OpenBSD': {
       $root_group = 'wheel'
     }
-    'freebsd': {
+    'FreeBSD': {
       $root_group = 'wheel'
     }
     default: {
@@ -20,37 +20,37 @@ class ssh::params {
   }
 
   case $::operatingsystem {
-    'centos', 'redhat', 'fedora': {
+    'CentOS', 'RedHat', 'Fedora': {
       $needs_install  = true
       $ssh_packages   = [ 'openssh-clients', 'openssh-server' ]
       $ssh_service    = 'sshd'
     }
-    'sles': {
+    'SLES': {
       $needs_install  = true
       $ssh_packages   = 'openssh'
       $ssh_service    = 'sshd'
     }
-    'ubuntu', 'debian': {
+    'Ubuntu', 'Debian': {
       $needs_install  = true
       $ssh_packages   = [ 'openssh-client', 'openssh-server' ]
       $ssh_service    = 'ssh'
     }
-    'darwin': {
+    'Darwin': {
       $needs_install = false
       $ssh_packages  = undef
       $ssh_service   = 'com.openssh.sshd'
     }
-    'freebsd': {
+    'FreeBSD': {
       $needs_install = false
       $ssh_packages  = undef
       $ssh_service   = 'sshd'
     }
-    'openbsd': {
+    'OpenBSD': {
       $needs_install = false
       $ssh_packages  = undef
       $ssh_service   = 'sshd'
     }
-    'solaris','sunos': {
+    'Solaris','SunOS': {
       $needs_install  = true
       $ssh_packages   = 'network/ssh'
       $ssh_service    = 'ssh'

--- a/spec/classes/ssh_hosts_spec.rb
+++ b/spec/classes/ssh_hosts_spec.rb
@@ -1,26 +1,14 @@
 require 'spec_helper'
 
 describe 'ssh::hosts' do
-  let(:facts) {
-    {
-      :hostname => 'flort',
-      :operatingsystem => 'OpenBSD',
-      :kernel => 'OpenBSD',
-      :concat_basedir => '/dne',
-      :sshdsakey => 'fffffffffffffffffffffff',
-      :sshecdsakey => 'fffffffffffffffffffffffffff',
-      :sshed25519key => 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-      :sshfp_dsa => 'SSHFP 2 1 ffffffffffffffffffffffffffffffffffffffff',
-      :sshfp_ecdsa => 'SSHFP 3 1 ffffffffffffffffffffffffffffffffffffffff',
-      :sshfp_ed25519 => 'SSHFP 4 1 ffffffffffffffffffffffffffffffffffffffff',
-      :sshfp_rsa => 'SSHFP 1 1 ffffffffffffffffffffffffffffffffffffffff',
-    }
-  }
+  on_supported_os.each do |os,facts|
+    let(:facts) { facts }
+    let(:params) { {:host_aliases => ['foo']} }
 
-  it { should contain_class('ssh::hosts') }
+    it { should contain_class('ssh::hosts') }
 
-  it { expect(exported_resources).to contain_sshkey('sshecdsakey-flort') }
-  it { expect(exported_resources).to contain_sshkey('sshed25519key-flort') }
-  it { expect(exported_resources).to contain_sshkey('sshdsakey-flort') }
-
+    it { expect(exported_resources).to contain_sshkey('sshecdsakey-foo') }
+    it { expect(exported_resources).to contain_sshkey('sshed25519key-foo') }
+    it { expect(exported_resources).to contain_sshkey('sshdsakey-foo') }
+  end
 end

--- a/spec/classes/ssh_install_spec.rb
+++ b/spec/classes/ssh_install_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'ssh::install' do
+
+  on_supported_os.each do |os,facts|
+    let(:facts) { facts }
+
+    it { is_expected.to contain_class('ssh::install') }
+    context 'when needs_install is true'  do
+      let(:params) { {:needs_install => true, :ssh_packages => 'openssh'} }
+      it { is_expected.to contain_package('openssh') }
+    end
+
+    context 'when needs_install is false'  do
+      let(:params) { {:needs_install => false, :ssh_packages => 'openssh'} }
+      it { is_expected.not_to contain_package('openssh') }
+    end
+  end
+end

--- a/spec/defines/keygen_spec.rb
+++ b/spec/defines/keygen_spec.rb
@@ -1,96 +1,92 @@
 require 'spec_helper'
 
 describe 'ssh::keygen' do
-  let(:facts) {
-    {
-      :operatingsystem => 'OpenBSD',
-      :kernel => 'OpenBSD',
-      :concat_basedir => '/dne'
-    }
-  }
 
-  let(:title) { 'Root' }
+  on_supported_os.each do |os,facts|
+    let(:facts) { facts }
+    let(:title) { 'Root' }
 
-  context 'when paramaters are valid' do
-    let(:params) {
-      {
-        :type   => 'rsa',
-        :size   => '2048',
-        :target => '/root/.ssh/id_rsa',
-      }
-    }
-    it do
-      should contain_exec('Generate ssh key for Root').with({
-        :command => '/usr/bin/ssh-keygen -t rsa -b 2048 -N "" -f /root/.ssh/id_rsa'
-      })
-    end
-
-    context 'when bad key type is passed' do
+    context 'when paramaters are valid' do
       let(:params) {
         {
-          :type   => 'asd',
+          :type   => 'rsa',
           :size   => '2048',
           :target => '/root/.ssh/id_rsa',
         }
       }
-      it { should raise_error(Puppet::Error, /"asd" does not match/) }
-    end
-
-    context 'when bad key size is passed' do
-      let(:params) {
-        {
-          :type   => 'rsa',
-          :size   => '512',
-        }
-      }
-      it { should raise_error(Puppet::Error, /RSA keys must be at least 768 bits/) }
-    end
-
-    context 'when ed25519 key size is passed' do
-      let(:params) {
-        {
-          :type   => 'ed25519',
-          :size   => '512',
-        }
-      }
       it do
         should contain_exec('Generate ssh key for Root').with({
-          :command => '/usr/bin/ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_rsa'
+          :command => '/usr/bin/ssh-keygen -t rsa -b 2048 -N "" -f /root/.ssh/id_rsa'
         })
-        should contain_notify('SSH ed25519 keys have a fixed length, size ignored')
       end
-    end
 
-    context 'when bad ecdsa key size is passed' do
-      let(:params) {
-        {
-          :type   => 'ecdsa',
-          :size   => '512',
+      context 'when bad key type is passed' do
+        let(:params) {
+          {
+            :type   => 'asd',
+            :size   => '2048',
+            :target => '/root/.ssh/id_rsa',
+          }
         }
-      }
-      it { should raise_error(Puppet::Error, /"512" does not match/) }
-    end
+        it { should raise_error(Puppet::Error, /"asd" does not match/) }
+      end
 
-    context 'when bad dsa key size is passed' do
-      let(:params) {
-        {
-          :type   => 'ecdsa',
-          :size   => '512',
+      context 'when bad key size is passed' do
+        let(:params) {
+          {
+            :type   => 'rsa',
+            :size   => '512',
+          }
         }
-      }
-      it { should raise_error(Puppet::Error, /"512" does not match/) }
-    end
+        it { should raise_error(Puppet::Error, /RSA keys must be at least 768 bits/) }
+      end
 
-    context 'when dsa key is requested' do
-      let(:params) {
-        {
-          :type => 'dsa',
+      context 'when ed25519 key size is passed' do
+        let(:params) {
+          {
+            :type   => 'ed25519',
+            :size   => '512',
+          }
         }
-      }
-      it do
-        should contain_exec('Generate ssh key for Root').with({
-          :command => '/usr/bin/ssh-keygen -t dsa -b 1024 -N "" -f /root/.ssh/id_rsa'
-        })
+        it do
+          should contain_exec('Generate ssh key for Root').with({
+            :command => '/usr/bin/ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_rsa'
+          })
+          should contain_notify('SSH ed25519 keys have a fixed length, size ignored')
+        end
+      end
+
+      context 'when bad ecdsa key size is passed' do
+        let(:params) {
+          {
+            :type   => 'ecdsa',
+            :size   => '512',
+          }
+        }
+        it { should raise_error(Puppet::Error, /"512" does not match/) }
+      end
+
+      context 'when bad dsa key size is passed' do
+        let(:params) {
+          {
+            :type   => 'ecdsa',
+            :size   => '512',
+          }
+        }
+        it { should raise_error(Puppet::Error, /"512" does not match/) }
+      end
+
+      context 'when dsa key is requested' do
+        let(:params) {
+          {
+            :type => 'dsa',
+          }
+        }
+        it do
+          should contain_exec('Generate ssh key for Root').with({
+            :command => '/usr/bin/ssh-keygen -t dsa -b 1024 -N "" -f /root/.ssh/id_rsa'
+          })
+        end
       end
     end
   end


### PR DESCRIPTION
Without this change, keys are distributed, but the titlevar is used to
represent the hostname of the system exporting the key.  This is a
problem because it means that the keys are not validated correctly
against the local cache in ssh_known_hosts.

This work adds an aliases variable with trusted defaults to allow the
hostname to be verified as an alias to the keyname.  Allows for the
distribution of multiple key types under the same set of host aliases.