### PR TITLE
Improve support for space separated options

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -4,6 +4,7 @@
 # through sshd_config(5) from a template.
 #
 class ssh::server::config (
+  $acceptenv                       = undef,
   $addressfamily                   = undef,
   $allowagentforwarding            = undef,
   $allowtcpforwarding              = undef,
@@ -81,10 +82,10 @@ class ssh::server::config (
   $log_level                = 'INFO', # underscore here because puppet
   $has_pam                  = false,
   $has_gssapi               = false,
-  $acceptenv                = undef,
 ) {
 
   $valid_keywords = [
+    'AcceptEnv',
     'AddressFamily',
     'AllowAgentForwarding',
     'AllowTcpForwarding',
@@ -159,6 +160,13 @@ class ssh::server::config (
     'X11Forwarding',
     'X11UseLocalhost',
     'XAuthLocation',
+  ]
+
+  $space_separated_keywords = [
+    'AcceptEnv',
+    'AuthorizedKeysFile',
+    'DenyGroups',
+    'DenyUsers',
   ]
 
   # Keywords that are configured with their own defined type.

--- a/spec/classes/ssh_server_config_spec.rb
+++ b/spec/classes/ssh_server_config_spec.rb
@@ -12,6 +12,7 @@ describe 'ssh::server::config' do
   it { should contain_class('ssh::server::config') }
 
   valid_keywords = [
+    'AcceptEnv',
     'AddressFamily',
     'AllowAgentForwarding',
     'AllowTcpForwarding',
@@ -99,6 +100,31 @@ describe 'ssh::server::config' do
     let(:params) { {:ciphers => ['chacha20-poly1305@openssh.com', 'aes256-ctr']} }
 
     it { should contain_concat__fragment('sshd_config').with_content(/^Ciphers chacha20-poly1305@openssh.com,aes256-ctr$/) }
-
   end
+
+  context 'with denyusers => []' do
+    let(:params) { {:acceptenv => ['AWS_*', 'TERM']} }
+
+    it { should contain_concat__fragment('sshd_config').with_content(/^AcceptEnv AWS_\* TERM$/) }
+  end
+
+  context 'with denyusers => []' do
+    let(:params) { {:denyusers => ['test1', 'test2']} }
+
+    it { should contain_concat__fragment('sshd_config').with_content(/^DenyUsers test1 test2$/) }
+  end
+
+  context 'with denygroups => []' do
+    let(:params) { {:denygroups => ['test1', 'test2']} }
+
+    it { should contain_concat__fragment('sshd_config').with_content(/^DenyGroups test1 test2$/) }
+  end
+
+  context 'with authorizedkeysfile => []' do
+    let(:params) { {:authorizedkeysfile => ['/path/one', '/path/two']} }
+
+    it { should contain_concat__fragment('sshd_config').with_content(/^AuthorizedKeysFile \/path\/one \/path\/two$/) }
+  end
+
+
 end

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -1,7 +1,4 @@
 LogLevel <%= @log_level.upcase %>
-<% Array(@acceptenv).each do |a| -%>
-AcceptEnv <%= a %>
-<% end -%>
 
 <%-
     @valid_keywords.map do |kw|
@@ -9,7 +6,11 @@ AcceptEnv <%= a %>
       next if scope[kw.downcase] == nil
 
       key = kw
-      value = Array(scope[kw.downcase]).join(',')
+      if @space_separated_keywords.include? key
+        value = Array(scope[kw.downcase]).join(' ')
+      else
+        value = Array(scope[kw.downcase]).join(',')
+      end
 -%>
 <%= [key,value].join(' ') %>
 <%-


### PR DESCRIPTION
This work adds a known list of options who's values are space separated
to allow the template to check if Array values received should joined by
commas or spaces.