### PR TITLE
Fix scope on `$root_group`

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -52,6 +52,6 @@ class ssh::server {
   $permitrootlogin = $ssh::server::config::permitrootlogin
 
   if $permitrootlogin != 'no' {
-    ssh::allowgroup { $root_group: }
+    ssh::allowgroup { $ssh::root_group: }
   }
 }


### PR DESCRIPTION
Without this change, permitting root login attempts to create an
`ssh::allowgroup` resource with an undefined title.