### PR TITLE
Add AcceptEnv to match

### DIFF
--- a/manifests/server/match.pp
+++ b/manifests/server/match.pp
@@ -13,6 +13,7 @@
 #   }
 #
 define ssh::server::match (
+  $acceptenv                       = undef,
   $allowagentforwarding            = undef,
   $allowgroups                     = undef,
   $allowtcpforwarding              = undef,
@@ -63,6 +64,7 @@ define ssh::server::match (
   ]
 
   $valid_keywords = [
+    'AcceptEnv',
     'AllowAgentForwarding',
     'AllowGroups',
     'AllowTcpForwarding',
@@ -99,6 +101,15 @@ define ssh::server::match (
     'X11DisplayOffset',
     'X11Forwarding',
     'X11UseLocalHost'
+  ]
+
+  # Keywords that are joined by spaces in the presence of multiple
+  # values
+  $space_separated_keywords = [
+    'AcceptEnv',
+    'AuthorizedKeysFile',
+    'DenyGroups',
+    'DenyUsers',
   ]
 
   concat::fragment { "sshd_config_match-${name}":

--- a/templates/sshd_config-match.erb
+++ b/templates/sshd_config-match.erb
@@ -1,10 +1,16 @@
 Match <%= @name %>
 <%-
-  @valid_keywords.map do |kw|
-    next if scope[kw.downcase] == :undef
-    next if scope[kw.downcase] == nil
+    @valid_keywords.map do |key|
+      next if scope[key.downcase] == :undef
+      next if scope[key.downcase] == nil
+
+      if @space_separated_keywords.include? key
+        value = Array(scope[key.downcase]).join(' ')
+      else
+        value = Array(scope[key.downcase]).join(',')
+      end
 -%>
-  <%= [kw,scope[kw.downcase]].join(' ') %>
+  <%= [key,value].join(' ') %>
 <%-
   end
 -%>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -1,15 +1,14 @@
 LogLevel <%= @log_level.upcase %>
 
 <%-
-    @valid_keywords.map do |kw|
-      next if scope[kw.downcase] == :undef
-      next if scope[kw.downcase] == nil
+    @valid_keywords.map do |key|
+      next if scope[key.downcase] == :undef
+      next if scope[key.downcase] == nil
 
-      key = kw
       if @space_separated_keywords.include? key
-        value = Array(scope[kw.downcase]).join(' ')
+        value = Array(scope[key.downcase]).join(' ')
       else
-        value = Array(scope[kw.downcase]).join(',')
+        value = Array(scope[key.downcase]).join(',')
       end
 -%>
 <%= [key,value].join(' ') %>


### PR DESCRIPTION
Without this change, there is no way to use match in combination with
AcceptEnv.  This change, adds the OpenSSHd AcceptEnv option to the match
resource.