### PR TITLE
Drop beaker gems from this module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.0
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 4.4.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.5.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.6.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.7.0" STRICT_VARIABLES=yes

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,3 @@ group :development do
   gem "puppet-blacksmith"
 end
 
-group :system_tests do
-  gem "beaker"
-  gem "beaker-rspec"
-end


### PR DESCRIPTION
Beaker is not in use on this module, and I'm not planning to work on it.
Here we drop the gems in order to avoid maintaining the versions
through the ruby lineage.