### PR TITLE
Fix bug for missing ssh_service variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class ssh (
   String $ssh_dir,
   String $sshd_config,
   String $ssh_config,
+  String $ssh_service,
   String $known_hosts,
   String $root_group,
   Boolean $service_hasrestart,


### PR DESCRIPTION
Without this change, references to the ssh_service variable are
unavailable due to the missing parameter.  Values are already present in
hiera, so adding the empty variable here should bridge the lookup
between reference and hiera.