### PR TITLE
Add order support for server match blocks

### DIFF
--- a/manifests/server/match.pp
+++ b/manifests/server/match.pp
@@ -50,6 +50,7 @@ define ssh::server::match (
   $x11displayoffset                = undef,
   $x11forwarding                   = undef,
   $x11uselocalhost                 = undef,
+  Integer[30, 99] $order           = 30,
 ) {
 
   include ssh::server
@@ -114,7 +115,7 @@ define ssh::server::match (
   ]
 
   concat::fragment { "sshd_config_match-${name}":
-    order   => '30',
+    order   => $order,
     target  => $ssh::sshd_config,
     content => template('ssh/sshd_config-match.erb'),
   }

--- a/spec/defines/server_match_spec.rb
+++ b/spec/defines/server_match_spec.rb
@@ -18,6 +18,26 @@ describe 'ssh::server::match' do
       else
       end
 
+      context 'with order set' do
+        let(:title) { 'Group nerds' }
+        let(:params) {
+          {
+            :order => 31
+          }
+        }
+        case facts[:osfamily]
+        when 'OpenBSD'
+          it do
+            should contain_class('ssh::server')
+            should contain_concat__fragment('sshd_config_match-Group nerds').with({
+              :target => '/etc/ssh/sshd_config',
+              :content => /^Match Group nerds$/,
+              :order => 31,
+            })
+          end
+        else
+        end
+      end
 
     end
   end


### PR DESCRIPTION
Without this change, the match order within a server config is not
tunable, and SSH matches only the first instance of the keyword.

Fixes #28