### PR TITLE
Allow generating SSH keys for users

### DIFF
--- a/manifests/keygen.pp
+++ b/manifests/keygen.pp
@@ -9,18 +9,18 @@
 #
 define ssh::keygen (
   Enum['dsa', 'ecdsa', 'ed25519', 'rsa', 'rsa1'] $type = 'rsa',
-  Integer $size                                        = 0,
-  String $passphrase                                   = '',
-  String $target                                       = '',
+  Optional[Integer] $size                              = undef,
+  Optional[String] $passphrase                         = undef,
+  Optional[String] $target                             = undef,
 ) {
 
-  if $size == 0 {
+  if !$size {
     $size_final = ssh::default_key_size($type)
   } else {
     $size_final = ssh::validate_key_size($type, $size)
   }
 
-  if $target == '' {
+  if !$target {
     $target_final = "/root/.ssh/id_${type}"
   } else {
     $target_final = $target

--- a/manifests/keygen.pp
+++ b/manifests/keygen.pp
@@ -34,7 +34,7 @@ define ssh::keygen (
   $args = [
     $type       ? { default => "-t ${type}" },
     $size_final ? { undef   => undef, default  => "-b ${size_final}" },
-    $passphrase ? { default => "-N \"${passphrase}\"" },
+    $passphrase ? { undef   => undef, default  => "-N \"${passphrase}\"" },
     $target     ? { default => "-f ${target_final}" },
   ]
 

--- a/manifests/keygen.pp
+++ b/manifests/keygen.pp
@@ -12,6 +12,7 @@ define ssh::keygen (
   Optional[Integer] $size                              = undef,
   Optional[String] $passphrase                         = undef,
   Optional[String] $target                             = undef,
+  String $user                                         = 'root',
 ) {
 
   if !$size {
@@ -21,7 +22,11 @@ define ssh::keygen (
   }
 
   if !$target {
-    $target_final = "/root/.ssh/id_${type}"
+    $user_home = $user ? {
+      'root'  => '/root',
+      default => "/home/${user}",
+    }
+    $target_final = "${user_home}/.ssh/id_${type}"
   } else {
     $target_final = $target
   }
@@ -39,5 +44,6 @@ define ssh::keygen (
   exec { "Generate ${type} SSH key for ${name}":
     command => "/usr/bin/ssh-keygen ${command}",
     creates => "${target_final}.pub",
+    user    => $user,
   }
 }

--- a/spec/defines/keygen_spec.rb
+++ b/spec/defines/keygen_spec.rb
@@ -15,7 +15,7 @@ describe 'ssh::keygen' do
       end
 
       it do
-        is_expected.to contain_exec('Generate rsa SSH key for Root').with(command: '/usr/bin/ssh-keygen -t rsa -b 2048 -N "" -f /root/.ssh/id_rsa')
+        is_expected.to contain_exec('Generate rsa SSH key for Root').with(command: '/usr/bin/ssh-keygen -t rsa -b 2048 -f /root/.ssh/id_rsa')
       end
 
       context 'when bad key type is passed' do
@@ -50,7 +50,7 @@ describe 'ssh::keygen' do
         end
 
         it do
-          is_expected.to contain_exec('Generate ed25519 SSH key for Root').with(command: '/usr/bin/ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_ed25519')
+          is_expected.to contain_exec('Generate ed25519 SSH key for Root').with(command: '/usr/bin/ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519')
           is_expected.to contain_notify('SSH ed25519 keys have a fixed length, size ignored')
         end
       end
@@ -76,7 +76,7 @@ describe 'ssh::keygen' do
 
         it { is_expected.to contain_notify('Only SSH dsa keys of 1024 size are valid, proceeding as such') }
         it do
-          is_expected.to contain_exec('Generate dsa SSH key for Root').with(command: '/usr/bin/ssh-keygen -t dsa -b 1024 -N "" -f /root/.ssh/id_dsa')
+          is_expected.to contain_exec('Generate dsa SSH key for Root').with(command: '/usr/bin/ssh-keygen -t dsa -b 1024 -f /root/.ssh/id_dsa')
         end
       end
 
@@ -88,7 +88,19 @@ describe 'ssh::keygen' do
         end
 
         it do
-          is_expected.to contain_exec('Generate dsa SSH key for Root').with(command: '/usr/bin/ssh-keygen -t dsa -b 1024 -N "" -f /root/.ssh/id_dsa')
+          is_expected.to contain_exec('Generate dsa SSH key for Root').with(command: '/usr/bin/ssh-keygen -t dsa -b 1024 -f /root/.ssh/id_dsa')
+        end
+      end
+
+      context 'when a passphrase is passed' do
+        let(:params) do
+          {
+            passphrase: 'this is my secret passphrase'
+          }
+        end
+
+        it do
+          is_expected.to contain_exec('Generate rsa SSH key for Root').with(command: %r{-N "this is my secret passphrase"})
         end
       end
 
@@ -101,7 +113,7 @@ describe 'ssh::keygen' do
         let(:title) { 'Charlie' }
 
         it do
-          is_expected.to contain_exec('Generate rsa SSH key for Charlie').with(user: 'charlie', command: '/usr/bin/ssh-keygen -t rsa -b 2048 -N "" -f /home/charlie/.ssh/id_rsa')
+          is_expected.to contain_exec('Generate rsa SSH key for Charlie').with(user: 'charlie', command: '/usr/bin/ssh-keygen -t rsa -b 2048 -f /home/charlie/.ssh/id_rsa')
         end
       end
     end

--- a/spec/defines/keygen_spec.rb
+++ b/spec/defines/keygen_spec.rb
@@ -91,6 +91,19 @@ describe 'ssh::keygen' do
           is_expected.to contain_exec('Generate dsa SSH key for Root').with(command: '/usr/bin/ssh-keygen -t dsa -b 1024 -N "" -f /root/.ssh/id_dsa')
         end
       end
+
+      context 'with a custom user' do
+        let(:params) do
+          {
+            user: 'charlie'
+          }
+        end
+        let(:title) { 'Charlie' }
+
+        it do
+          is_expected.to contain_exec('Generate rsa SSH key for Charlie').with(user: 'charlie', command: '/usr/bin/ssh-keygen -t rsa -b 2048 -N "" -f /home/charlie/.ssh/id_rsa')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The `ssh::keygen` defined type allows to generate keys for the root user.  At $WORK, we extended the module to allow generating keys for random users, and think this could be upstreamed.

I included some minor refactoring we did internally to this PR.  Let me know if you do not like these enhancements and I'll update accordingly.