### PR TITLE
Test against Puppet 6 and fix CI

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,7 @@ fixtures:
     ssh: "#{source_dir}"
   repositories:
     concat: git://github.com/puppetlabs/puppetlabs-concat.git
+    sshkeys:
+      repo: git://github.com/puppetlabs/puppetlabs-sshkeys_core.git
+      puppet_version: '>= 6.0'
     stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,21 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.9
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12
   - rvm: 2.4.4
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=test
+    env: PUPPET_VERSION="~> 5.0" CHECK=test PARALLEL_TEST_PROCESSORS=12
   - rvm: 2.5.1
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=test_with_coveralls
-  - rvm: 2.4.4
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=rubocop
+    env: PUPPET_VERSION="~> 6.0" CHECK=test
   - rvm: 2.5.1
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=build
+    env: PUPPET_VERSION="~> 6.0" CHECK=test_with_coveralls
+  - rvm: 2.5.1
+    bundler_args: --without system_tests development release
+    env: PUPPET_VERSION="~> 6.0" CHECK=rubocop
+  - rvm: 2.5.1
+    bundler_args: --without system_tests development release
+    env: PUPPET_VERSION="~> 6.0" CHECK=build
 branches:
   only:
   - master

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ group :test do
   gem 'rspec-puppet', '~> 2.5',                                     :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
+  gem 'pdk',                                                        :require => false
+  gem 'puppet-module',                                              :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false
   gem 'puppet-lint-version_comparison-check',                       :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ else
   gem 'facter', :require => false, :groups => [:test]
 end
 
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 5.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
+ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 6.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby


### PR DESCRIPTION
Puppet 4 dependencies are broken and would need tweaking, but since Puppet 4 has reached EOL a few month ago, just test supported Puppet releases.

------

… but maybe you would prefer managing this through ModuleSync, but xaque208/modulesync_config seems to generate a different configuration for this module, so I was not sure about what to do :confused: ?