### PR TITLE
Hiera 5 support

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,11 +1,12 @@
 ---
-version: 4
-datadir: data
+version: 5
+
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
 hierarchy:
   - name: "osfamily"
-    backend: yaml
-    path: "os/%{facts.os.family}"
+    path: "os/%{facts.os.family}.yaml"
   - name: "common"
-    backend: yaml
-    path: "common"
-
+    path: "common.yaml"

--- a/metadata.json
+++ b/metadata.json
@@ -58,6 +58,5 @@
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.0.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
This clears up a couple warnings I was seeing when running `puppet apply` with this module

```
Warning: /tmp/modules/ssh/hiera.yaml: Use of 'hiera.yaml' version 4 is deprecated. It should be converted to version 5
Warning: Defining "data_provider": "hiera" in metadata.json is deprecated.
```