### PR TITLE
Improve ssh_known_hosts content generation

### DIFF
--- a/manifests/hosts.pp
+++ b/manifests/hosts.pp
@@ -8,25 +8,28 @@ class ssh::hosts (
   Array[String] $host_aliases = [$trusted['certname'], $trusted['hostname']],
   Boolean $collect_keys       = true,
 ) {
+  $first = $host_aliases[0]
+  $rest  = $host_aliases[1, -1]
+
   if $facts.dig('ssh','dsa','key') {
-    @@sshkey { "sshdsakey-${host_aliases[0]}":
-      host_aliases => $host_aliases,
+    @@sshkey { "${first}@ssh-dss":
+      host_aliases => $rest,
       type         => 'ssh-dss',
       key          => $facts['ssh']['dsa']['key'],
     }
   }
 
   if $facts.dig('ssh','ecdsa','key') {
-    @@sshkey { "sshecdsakey-${host_aliases[0]}":
-      host_aliases => $host_aliases,
+    @@sshkey { "${first}@ecdsa-sha2-nistp256":
+      host_aliases => $rest,
       type         => 'ecdsa-sha2-nistp256',
       key          => $facts['ssh']['ecdsa']['key'],
     }
   }
 
   if $facts.dig('ssh','ed25519','key') {
-    @@sshkey { "sshed25519key-${host_aliases[0]}":
-      host_aliases => $host_aliases,
+    @@sshkey { "${first}@ssh-ed25519":
+      host_aliases => $rest,
       type         => 'ssh-ed25519',
       key          => $facts['ssh']['ed25519']['key'],
     }

--- a/metadata.json
+++ b/metadata.json
@@ -61,6 +61,10 @@
       "version_requirement": ">= 1.1.0"
     },
     {
+      "name": "puppetlabs/sshkey_core",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.0.0"
     }

--- a/spec/classes/ssh_hosts_spec.rb
+++ b/spec/classes/ssh_hosts_spec.rb
@@ -9,15 +9,15 @@ describe 'ssh::hosts' do
       it { is_expected.to contain_class('ssh::hosts') }
 
       if facts.dig(:ssh, :ecdsa)
-        it { expect(exported_resources).to contain_sshkey('sshecdsakey-foo') }
+        it { expect(exported_resources).to contain_sshkey('foo@ecdsa-sha2-nistp256').with(type: 'ecdsa-sha2-nistp256') }
       end
 
       if facts.dig(:ssh, :dsa)
-        it { expect(exported_resources).to contain_sshkey('sshdsakey-foo') }
+        it { expect(exported_resources).to contain_sshkey('foo@ssh-dss').with(type: 'ssh-dss') }
       end
 
       if facts.dig(:ssh, :ed25519)
-        it { expect(exported_resources).to contain_sshkey('sshed25519key-foo') }
+        it { expect(exported_resources).to contain_sshkey('foo@ssh-ed25519').with(type: 'ssh-ed25519') }
       end
     end
   end


### PR DESCRIPTION
This module rely on the `sshkeys` type which is now provided by the
`puppetlabs/sshkeys_core` module (since Puppet 6.0 which moved a bunch of
modules out of puppet core).

In order to avoid duplicate resources, this module used custom resource
names in the form `sshdsakey-<hostname>`, `sshecdsakey-<hostname>` and
`sshed25519key-<hostname>`, which are present in the managed
`ssh_known_hosts` file, and can be read in some situations like a shell
completion.  However, such names being just workarounds, they are
unlikely to resolve to something valid, and if they do, they may resolve
to the wrong target.

Version 2.0.0 of the `sshkeys_core` module [reworked] the way resource
title is managed, allowing us to have a clean `ssh_known_hosts` file
generated.  All versions of Puppet 7 ship with a compatible version of
`sshkeys_core` bundled, yet Puppet 6 does not.  However, it is possible
to use a newer `sshkeys_core` on Puppet 6 by adding it to the Puppetfile
as any other module.

To avoid usage of an incompatible module, explicitely add the dependency
to the metadata file.

[reworked]: https://github.com/puppetlabs/puppetlabs-sshkeys_core/pull/27