### PR TITLE
Fix sshkeys_core module name

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
       "version_requirement": ">= 1.1.0"
     },
     {
-      "name": "puppetlabs/sshkey_core",
+      "name": "puppetlabs/sshkeys_core",
       "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {


### PR DESCRIPTION
Installation fails using `librarian-puppet` since `puppetlabs/sshkey_core` is not a valid Forge package name